### PR TITLE
Fix sharing walls community

### DIFF
--- a/force-app/main/default/classes/ProposalUpdate.cls
+++ b/force-app/main/default/classes/ProposalUpdate.cls
@@ -316,7 +316,7 @@ public with sharing class ProposalUpdate {
         // Vars for other fields
         Id countryId, regionId, regionOverrideId, firstGrantId, latestGrantId;
         // Build interpreter for status calculations.
-        String fsGroup = Utilities.FSGroupOfUser(a.OwnerId);
+        String fsGroup = Utilities.fsGroupNameByUser(a.OwnerId);
         Template__c t = [
             SELECT Id
             FROM Template__c

--- a/force-app/main/default/classes/Utilities.cls
+++ b/force-app/main/default/classes/Utilities.cls
@@ -1174,21 +1174,42 @@ global inherited sharing class Utilities {
         return [SELECT Name FROM Profile WHERE Id = :profileId].Name;
     }
 
-    // Return public group name of FS Group to which user belongs
-    public static String FSGroupOfUser(Id usrId) {
+    // Return default record owner Id for FSGroup of given user.
+    public static Id fsDefaultRecordOwnerIdByUser(Id usrId) {
+        FS_Group_Settings__mdt fsGroup = fsGroupOfUser(usrId);
+        Id ownerId;
+        if (fsGroup!=null) {
+            ownerId = [SELECT Id, UserRoleId, UserRole.DeveloperName 
+                FROM User
+                WHERE UserRole.DeveloperName =:fsGroup.Designated_Role_for_Ownership__c][0].Id;
+        }
+        return ownerId;
+    }
+
+    // Return public group name of FSGroup for given user.
+    public static String fsGroupNameByUser(Id usrId) {
+        FS_Group_Settings__mdt fsGroup = fsGroupOfUser(usrId);
+        if (fsGroup!=null) return fsGroup.Public_Group_Name__c;
+        return '';
+    }
+
+    // Return public group name of FS Group for given user.
+    public static FS_Group_Settings__mdt fsGroupOfUser(Id usrId) {
         // If Customer Community user, retrieve FS Group by SF Profile and custom metadata type records.
         // Else, go upstream in hierarchy from user's role to identify FS Group, if any.
-        FS_Group_Settings__mdt[] fsGroups = [SELECT Id, DeveloperName, Designated_Role_for_Ownership__c, Public_Group_Name__c 
-        FROM FS_Group_Settings__mdt 
-        WHERE Active__c = true];
+        FS_Group_Settings__mdt[] fsGroups = fetchRecords(
+            'FS_Group_Settings__mdt',
+            'WHERE Active__c = true',
+            null
+        );
         User usr = [SELECT Id, Profile.Name, Profile.UserLicense.Name, UserRoleId FROM User WHERE Id=:usrId];
         Boolean isCommunityUsr = (usr.Profile.UserLicense.Name == 'Customer Community Login');
-        Map<String, String> groupRole = new Map<String, String>();
+        Map<String, FS_Group_Settings__mdt> groupRole = new Map<String, FS_Group_Settings__mdt>();
         for (FS_Group_Settings__mdt fsGrp : fsGroups) {
             if (isCommunityUsr && usr.Profile.Name.contains(fsGrp.DeveloperName)) {
-                return fsGrp.Public_Group_Name__c;
+                return fsGrp;
             } else {
-                groupRole.put(fsGrp.Designated_Role_for_Ownership__c, fsGrp.Public_Group_Name__c);
+                groupRole.put(fsGrp.Designated_Role_for_Ownership__c, fsGrp);
             }
         }
         Map<Id, UserRole> usrRoles = new Map<Id, UserRole>([
@@ -1201,7 +1222,7 @@ global inherited sharing class Utilities {
             if (groupRole.containsKey(thisRole.DeveloperName)) return groupRole.get(thisRole.DeveloperName);
             thisRole = usrRoles.get(thisRole.ParentRoleId);
         }
-        return '';
+        return null;
     }
 
     // Return new page reference for given record.

--- a/force-app/main/default/classes/UtilitiesTest.cls
+++ b/force-app/main/default/classes/UtilitiesTest.cls
@@ -137,7 +137,7 @@ public class UtilitiesTest {
         dec = Utilities.maxDecimal(3.1, null);
         ls = Utilities.currentUserPermissionSetNames();
         s = Utilities.currentUserProfileName();
-        s = Utilities.FSGroupOfUser(UserInfo.getUserId());
+        s = Utilities.fsGroupNameByUser(UserInfo.getUserId());
         Utilities.ExceptionAlertEmailToIM(null, 'test error');
         Utilities.pageReferenceForRecord(acct);
         Utilities.defaultLanguage();

--- a/manifest/tempApexClass.xml
+++ b/manifest/tempApexClass.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
+		<members>ProposalUpdate</members>
 		<members>Utilities</members>
 		<members>UtilitiesTest</members>
 		<name>ApexClass</name>

--- a/scripts/apex/test.apex
+++ b/scripts/apex/test.apex
@@ -1,37 +1,8 @@
 /* ApexLog[] logs = [SELECT Id FROM ApexLog];
 system.debug(logs.size());
 */
-Id usrId = '0058c00000BKxMD';
-User usr = [select id, Name, ProfileId, Profile.UserLicense.name from user where Id=:usrId];
-system.debug('userprofile: ' + usr.Profile.UserLicense.name);
-String fsGroup = FSGroupOfUser(usrId);
-system.debug('fsgroup: ' + fsGroup);
-
-// Return public group name of FS Group to which user belongs
-    public static String FSGroupOfUser(Id usrId) {
-        // If Customer Community user, retrieve FS Group by SF Profile and custom metadata type records.
-        // Else, go upstream in hierarchy from user's role to identify FS Group, if any.
-        FS_Group_Settings__mdt[] fsGroups = [SELECT Id, DeveloperName, Designated_Role_for_Ownership__c, Public_Group_Name__c 
-        FROM FS_Group_Settings__mdt 
-        WHERE Active__c = true];
-        User usr = [SELECT Id, Profile.Name, Profile.UserLicense.Name, UserRoleId FROM User WHERE Id=:usrId];
-        Boolean isCommunityUsr = (usr.Profile.UserLicense.Name == 'Customer Community Login');
-        Map<String, String> groupRole = new Map<String, String>();
-        for (FS_Group_Settings__mdt fsGrp : fsGroups) {
-            if (isCommunityUsr && usr.Profile.Name.contains(fsGrp.DeveloperName)) {
-                return fsGrp.Public_Group_Name__c;
-            }
-            groupRole.put(fsGrp.Designated_Role_for_Ownership__c, fsGrp.Public_Group_Name__c);
-        }
-        Map<Id, UserRole> usrRoles = new Map<Id, UserRole>([
-            SELECT Id, DeveloperName, ParentRoleId 
-            FROM UserRole]);
-        UserRole thisRole = new UserRole();
-        thisRole = usrRoles.get(usr.UserRoleId);
-        // Cycle through parent roles to find relevant FS Group
-        while (thisRole != null) {
-            if (groupRole.containsKey(thisRole.DeveloperName)) return groupRole.get(thisRole.DeveloperName);
-            thisRole = usrRoles.get(thisRole.ParentRoleId);
-        }
-        return '';
-    }
+Id usrId = '0058c000008Rzwz';
+String fsGroupName = Utilities.fsGroupNameByUser(usrId);
+Id fsDefaultOwnerId = Utilities.fsDefaultRecordOwnerIdByUser(usrId);
+system.debug('fsgroupname: ' + fsGroupName);
+system.debug('fsDefaultOwnerId: ' + fsDefaultOwnerId);


### PR DESCRIPTION
Hi @RandyTrigg,

I changed the original method to return the FS group custom metadata type record (instead of the group name) -- and updated the name to fsGroupOfUser.

Then I added caller methods:

- fsGroupNameByUser returns the group name, and
- fsDefaultRecordOwnerIdByUser, which returns the owner Id for the fs group.

I deployed and tested them in my sandbox but didn't deploy in fsdb production since it will break existing code. This branch also contains updates to ProposalUpdate, which now calls fsGroupNameByUser.

Let me know if you notice any issues. Thanks!